### PR TITLE
Support SQL log level configuration

### DIFF
--- a/src/duct/database/sql/hikaricp.clj
+++ b/src/duct/database/sql/hikaricp.clj
@@ -20,30 +20,30 @@
         params (query-parameter-lists query-info)]
     (into [query] (if (= (count params) 1) (first params) params))))
 
-(defn- logging-listener [logger]
+(defn- logging-listener [logger level]
   (reify QueryExecutionListener
     (beforeQuery [_ _ _])
     (afterQuery [_ exec-info query-infos]
       (let [elapsed (.getElapsedTime exec-info)
             queries (mapv logged-query query-infos)]
         (if (= (count queries) 1)
-          (log/log logger :info ::sql/query {:query (first queries), :elapsed elapsed})
-          (log/log logger :info ::sql/batch-query {:queries queries, :elapsed elapsed}))))))
+          (log/log logger level ::sql/query {:query (first queries), :elapsed elapsed})
+          (log/log logger level ::sql/batch-query {:queries queries, :elapsed elapsed}))))))
 
-(defn- wrap-logger [datasource logger]
+(defn- wrap-logger [datasource logger level]
   (doto (ProxyDataSource. datasource)
-    (.addListener (logging-listener logger))))
+    (.addListener (logging-listener logger level))))
 
 (defn- unwrap-logger [^DataSource datasource]
   (.unwrap datasource DataSource))
 
 (defmethod ig/init-key :duct.database.sql/hikaricp
-  [_ {:keys [logger connection-uri jdbc-url] :as options}]
+  [_ {:keys [logger connection-uri jdbc-url level] :as options :or {level :info}}]
   (sql/->Boundary {:datasource
                    (-> (dissoc options :logger)
                        (assoc :jdbc-url (or jdbc-url connection-uri))
                        (hikari-cp/make-datasource)
-                       (cond-> logger (wrap-logger logger)))}))
+                       (cond-> logger (wrap-logger logger level)))}))
 
 (defmethod ig/halt-key! :duct.database.sql/hikaricp [_ {:keys [spec]}]
   (let [ds (unwrap-logger (:datasource spec))]

--- a/test/duct/database/sql/hikaricp_test.clj
+++ b/test/duct/database/sql/hikaricp_test.clj
@@ -79,3 +79,22 @@
     (is (not (.isClosed (unwrap-logger (:datasource spec)))))
     (ig/halt-key! ::sql/hikaricp hikaricp)
     (is (.isClosed (unwrap-logger (:datasource spec))))))
+
+(deftest log-level-configuration
+  (testing "configured log level"
+    (let [logs     (atom [])
+          logger   (->AtomLogger logs)
+          hikaricp (ig/init-key ::sql/hikaricp {:jdbc-url "jdbc:sqlite:"
+                                                :logger logger
+                                                :level :trace})
+          spec     (:spec hikaricp)]
+      (jdbc/execute! spec ["CREATE TABLE foo (id INT, body TEXT)"])
+      (jdbc/db-do-commands spec ["INSERT INTO foo VALUES (1, 'a')"
+                                 "INSERT INTO foo VALUES (2, 'b')"])
+      (jdbc/query spec ["SELECT * FROM foo"])
+      (is (= (map remove-elapsed @logs)
+            [[:trace ::sql/query {:query ["CREATE TABLE foo (id INT, body TEXT)"]}]
+             [:trace ::sql/batch-query {:queries [["INSERT INTO foo VALUES (1, 'a')"]
+                                                  ["INSERT INTO foo VALUES (2, 'b')"]]}]
+             [:trace ::sql/query {:query ["SELECT * FROM foo"]}]]))
+      (ig/halt-key! ::sql/hikaricp hikaricp))))


### PR DESCRIPTION
Support to set log level of `::sql/query` and `::sql/batch-query` from configuration (e.g config.edn).